### PR TITLE
Adicionando instruções de clonagem do repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Roadmap para se tornar uma cientista da computação na UFCG.
 ## Configuração de Instalação
 
 ``` bash
+# clonando o repositório
+$ git clone https://github.com/OpenDevUFCG/roadmap-cc.git
+$ cd roadmap-cc
+
 # instalar dependências
 $ yarn install
 


### PR DESCRIPTION
Adicionado trecho ensinando a clonar o repositório. Pode ser útil para usuários em que isso não é tão obvio ainda.